### PR TITLE
fix(tag-input): re-order className for correct cn merge

### DIFF
--- a/packages/emblor/src/tag/tag-input.tsx
+++ b/packages/emblor/src/tag/tag-input.tsx
@@ -334,8 +334,8 @@ const TagInput = React.forwardRef<HTMLInputElement, TagInputProps>((props, ref) 
                   onBlur={handleInputBlur}
                   {...inputProps}
                   className={cn(
-                    className,
                     'border-0 h-5 bg-transparent focus-visible:ring-0 focus-visible:ring-transparent focus-visible:ring-offset-0 flex-1 w-fit',
+                    className,
                   )}
                   autoComplete={enableAutocomplete ? 'on' : 'off'}
                   list={enableAutocomplete ? 'autocomplete-options' : undefined}


### PR DESCRIPTION
The `className` of the `TagInput` element was configured backwards, so tailwind merge wasn't properly applying className overrides.

See #52 for more context on the issue

Closes #52 