### PR TITLE
fix: tsup is a dev dependency

### DIFF
--- a/packages/emblor/package.json
+++ b/packages/emblor/package.json
@@ -57,6 +57,7 @@
     "@types/node": "^18.11.13",
     "@types/react": "^18.0.26",
     "react": "^18.2.0",
+    "tsup": "^6.5.0",
     "typescript": "^4.8.4"
   },
   "peerDependencies": {
@@ -72,7 +73,6 @@
     "clsx": "latest",
     "cmdk": "^0.2.0",
     "react-easy-sort": "^1.6.0",
-    "tailwind-merge": "latest",
-    "tsup": "^6.5.0"
+    "tailwind-merge": "latest"
   }
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -78,9 +78,6 @@ importers:
       tailwind-merge:
         specifier: latest
         version: 2.5.2
-      tsup:
-        specifier: ^6.5.0
-        version: 6.7.0(postcss@8.4.29)(typescript@4.9.5)
     devDependencies:
       '@types/node':
         specifier: ^18.11.13
@@ -91,6 +88,9 @@ importers:
       react:
         specifier: ^18.2.0
         version: 18.2.0
+      tsup:
+        specifier: ^6.5.0
+        version: 6.7.0(postcss@8.4.29)(typescript@4.9.5)
       typescript:
         specifier: ^4.8.4
         version: 4.9.5
@@ -3914,9 +3914,11 @@ packages:
 
   shikiji-core@0.10.2:
     resolution: {integrity: sha512-9Of8HMlF96usXJHmCL3Gd0Fcf0EcyJUF9m8EoAKKd98mHXi0La2AZl1h6PegSFGtiYcBDK/fLuKbDa1l16r1fA==}
+    deprecated: Deprecated, use @shikijs/core instead
 
   shikiji@0.10.2:
     resolution: {integrity: sha512-wtZg3T0vtYV2PnqusWQs3mDaJBdCPWxFDrBM/SE5LfrX92gjUvfEMlc+vJnoKY6Z/S44OWaCRzNIsdBRWcTAiw==}
+    deprecated: Deprecated, use shiki instead
 
   side-channel@1.0.6:
     resolution: {integrity: sha512-fDW/EZ6Q9RiO8eFG8Hj+7u/oW+XrPTIChwCOM2+th2A6OblDtYYIpve9m+KvI9Z4C9qSEXlaGR6bTEYHReuglA==}


### PR DESCRIPTION
Resolves #110

Updates the dev dependencies to include `tsup`. tsup is only used during the build/bundle phase and is not needed as a production dependency of the package. 